### PR TITLE
Fix yaml formatting issue with quotes

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -65,7 +65,7 @@ def read_paper(row: dict[str, str]) -> str:
         link_to_repo = f"\n# Repository\n{link_to_repo}\n"
 
     return TEMPLATE.format(
-        title=row["Title"],
+        title=row["Title"].replace("'", "''"),
         authors=authors,
         text=row["Abstract"],
         references=link_to_repo,


### PR DESCRIPTION
Sometimes if there is a quote in a title this can break the yaml formatting. This PR replaces quote by double quotes and fixes it