### PR TITLE
Bug with a long list of authors not fitting a page

### DIFF
--- a/template/ossfeconf.sty
+++ b/template/ossfeconf.sty
@@ -13,6 +13,7 @@
 \usepackage{lmodern}
 \usepackage{microtype}
 \usepackage{graphbox}
+\usepackage{authblk}
 
 \renewcommand{\familydefault}{\sfdefault}
 \renewcommand{\marginpar}[1]{

--- a/template/template.tex
+++ b/template/template.tex
@@ -24,18 +24,13 @@ pdfkeywords={[-doc.tags-]}
 
 \title{[-doc.title-]}
 
-\author{[# for author in doc.authors -#]
-\bfseries [-author.name-]\mdseries\\
-[#- if author.affiliations #]
-[# for affiliation in author.affiliations #]
-[-affiliation.value.name-][# if not loop.last #], [# endif #]
-[# endfor #]\\
-[#- endif -#]
-[#- if not loop.last -#]
-\AND
-[#- endif -#]
-[#- endfor -#]
-}
+[# for author in doc.authors #]
+    \author[[-- author.affiliations|join(",", "index") --]]{[-author.name-]}
+[# endfor #]
+
+[# for affiliation in doc.affiliations #]
+    \affil[[-affiliation.index-]]{[-affiliation.value.name-]}
+[# endfor #]
 
 \date{18th March 2025}
 


### PR DESCRIPTION
This PR resolves #33 by changing the display format of the list of authors. Now the list of authors should have the following structure and not exceed a single page:

Author1 $^{1}$, Author2 $^{2,3}$, Author3 $^{1}$

$^{1}$ Affiliation1
$^{2}$ Affiliation2
$^{3}$ Affiliation3
