### PR TITLE
Wrong co-author affiliation

### DIFF
--- a/book/abstracts/vladimir-modelling.md
+++ b/book/abstracts/vladimir-modelling.md
@@ -12,7 +12,7 @@ authors:
       - Ioffe Institute of Russian Academy of Sciences
   - name: Igor Gabis
     affiliations:
-      - Ioffe Institute of Russian Academy of Sciences
+      - St Petersburg University
   - name: Vitaliy Efimov
     affiliations:
       - National Research Nuclear University MEPhI


### PR DESCRIPTION
We found that affiliation of one of my co-authors is incorrect. I replaced it.

I apologise for the inconvenience with my abstracts.