### PR TITLE
Removed link to website

### DIFF
--- a/book/myst.yml
+++ b/book/myst.yml
@@ -19,7 +19,5 @@ site:
     logo: assets/OSSFE_logo.png
     favicon: assets/OSSFE_logo.png
   actions:
-    - title: OSSFE website
-      url: https://ossfe.github.io/
     - title: Suggest Edits on GitHub
       url: https://github.com/OSSFE/OSSFE_2025


### PR DESCRIPTION
This PR removes the top link to the website as it's no longer needed
<img width="1104" alt="image" src="https://github.com/user-attachments/assets/ff3928fb-57a6-45fb-9675-2994250ac372" />
